### PR TITLE
Temporarely set normalize_y=False to avoid divition by zero in sklear…

### DIFF
--- a/ProcessOptimizer/utils.py
+++ b/ProcessOptimizer/utils.py
@@ -351,7 +351,7 @@ def cook_estimator(base_estimator, space=None, length_scale_bounds=None, length_
 
         base_estimator = GaussianProcessRegressor(
             kernel=cov_amplitude * other_kernel,
-            normalize_y=True, noise="gaussian",
+            normalize_y=False, noise="gaussian",
             n_restarts_optimizer=4)
     elif base_estimator == "RF":
         base_estimator = RandomForestRegressor(n_estimators=100,


### PR DESCRIPTION
normalize_y set to False to avoid divide by zero error in SKLEARN > 0.23