### PR TITLE
Bug fix when asking for multiple points using Steinerberger strategy

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -448,7 +448,7 @@ class Optimizer(object):
         X = []
         for i in range(n_points):
             if i>0 and strategy == "stbr" and self._n_initial_points <1:
-                x = opt.stbr_scipy[0]
+                x = opt.stbr_scipy()[0]
             else:
                 x = opt.ask()
             X.append(x)


### PR DESCRIPTION


Fixed a bug which would cause an error when asking for multiple points using Steinerberger strategy after initial point is calculated. The function call to stbr_scipy on line 451 in optimizer.py was missing "()".