### PR TITLE
Temporarily lock sklearn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 pandas
-scikit-learn >= 0.24.2 #To avoid issues with normalize_y
+scikit-learn == 0.24.2 #To avoid issues with normalize_y
 matplotlib
 pytest
 nose

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='ProcessOptimizer',
           'ProcessOptimizer.learning.gaussian_process'
           ],
       install_requires=['numpy', 'matplotlib', 'scipy',
-                        'scikit-learn>=0.24.2', 'six', 'deap', 'pyYAML'],
+                        'scikit-learn==0.24.2', 'six', 'deap', 'pyYAML'],
       extras_require={
           "bokeh": ['bokeh', 'tornado']
           },


### PR DESCRIPTION
Temporarely lock sklearn version. 
Sklearn vs 1.0.0 is breaking large parts of the code when using gaussian processes. (Due to depredated use of the y_train_mean feature. 
This PR sets sklearn to version 0.24.2, while we fix the ussue