### PR TITLE
Makes the LHS sampling identical for continuous and discrete dimensions

### DIFF
--- a/ProcessOptimizer/space/space.py
+++ b/ProcessOptimizer/space/space.py
@@ -305,10 +305,13 @@ class Real(Dimension):
         * `n` [int]
             Number of samples.
         """
-        a = (np.arange(n)+0.5)/n  # Evenly distributed betweeen 0 and 1
+        # Generate sample points by splitting the space 0 to 1 into n pieces
+        # and picking the middle of each piece. Samples are spaced 1/n apart
+        # inside the interval with a buffer of half a step size to the extremes
+        samples = (np.arange(n)+0.5)/n
 
-        # Transform to the bounds of this dimension
-        return a*(self.high-self.low)+self.low
+        # Transform the samples to the range used for this dimension
+        return samples*(self.high - self.low) + self.low
 
 
 class Integer(Dimension):
@@ -413,9 +416,17 @@ class Integer(Dimension):
         * `n` [int]
             Number of samples.
         """
-        rounded_numbers = np.round(np.linspace(self.low, self.high, n))
-        # convert to a list of integers
-        return [int(a) for a in rounded_numbers]
+        # Generate sample points by splitting the space 0 to 1 into n pieces
+        # and picking the middle of each piece. Samples are spaced 1/n apart
+        # inside the interval with a buffer of half a step size to the extremes
+        samples = (np.arange(n)+0.5)/n
+        # Transform the samples to the range used for this dimension and then 
+        # round them back to integers. If your space is less than n wide, some 
+        # of your samples will be rounded to the same number
+        samples = np.round(samples*(self.high - self.low) + self.low)
+        
+        # Convert samples to a list of integers
+        return samples.astype(int)
 
 
 class Categorical(Dimension):

--- a/ProcessOptimizer/tests/test_space.py
+++ b/ProcessOptimizer/tests/test_space.py
@@ -681,8 +681,8 @@ def test_lhs_arange():
     # Test that the Integer and Real classes return identical points after
     # rounding, using Numpy's allclose function
     assert np.allclose(lhs_int, lhs_real, atol=0.5)
-    # Test that the Integer class returns ints in all locations
-    # assert all([isinstance(x,np.int32) for x in lhs_int])
+    # Test that the Integer class returns values that are ints for all intents 
+    # and purposes
     assert all([np.mod(x,1) == 0 for x in lhs_int])
     # Test that the Real class returns flots in all locations
     assert all([isinstance(x,np.float64) for x in lhs_real])

--- a/ProcessOptimizer/tests/test_space.py
+++ b/ProcessOptimizer/tests/test_space.py
@@ -682,7 +682,8 @@ def test_lhs_arange():
     # rounding, using Numpy's allclose function
     assert np.allclose(lhs_int, lhs_real, atol=0.5)
     # Test that the Integer class returns ints in all locations
-    assert all([isinstance(x,np.int32) for x in lhs_int])
+    # assert all([isinstance(x,np.int32) for x in lhs_int])
+    assert all([np.mod(x,1) == 0 for x in lhs_int])
     # Test that the Real class returns flots in all locations
     assert all([isinstance(x,np.float64) for x in lhs_real])
 

--- a/ProcessOptimizer/tests/test_space.py
+++ b/ProcessOptimizer/tests/test_space.py
@@ -671,12 +671,20 @@ def test_purely_categorical_space():
 
 @pytest.mark.fast_test
 def test_lhs_arange():
-    dim = Categorical(["a", "b", "c"])
-    dim.lhs_arange(10)
-    dim = Integer(1, 20)
-    dim.lhs_arange(10)
-    dim = Real(-10, 20)
-    dim.lhs_arange(10)
+    # Test that the latin hypercube sampling functions run normally
+    dim_cat = Categorical(["a", "b", "c"])
+    dim_cat.lhs_arange(10)
+    dim_int = Integer(-10, 20)
+    lhs_int = dim_int.lhs_arange(10)
+    dim_real = Real(-10, 20)
+    lhs_real = dim_real.lhs_arange(10)
+    # Test that the Integer and Real classes return identical points after
+    # rounding, using Numpy's allclose function
+    assert np.allclose(lhs_int, lhs_real, atol=0.5)
+    # Test that the Integer class returns ints in all locations
+    assert all([isinstance(x,np.int32) for x in lhs_int])
+    # Test that the Real class returns flots in all locations
+    assert all([isinstance(x,np.float64) for x in lhs_real])
 
 
 @pytest.mark.fast_test
@@ -687,3 +695,4 @@ def test_lhs():
     samples = SPACE.lhs(10)
     assert len(samples) == 10
     assert len(samples[0]) == 3
+


### PR DESCRIPTION
I have tweaked the sampling algorithm for the case of a dimension with integer numbers so that the sample points are identical for continuous and discrete dimensions, to within rounding. The change results in the code using the same formula to pick the points in both cases.  

I also decided to cast the sample points to int using the numpy "astype" functionality, instead of having a for-loop inside the return statement, which I think is a bit confusing. Be aware that this changes the _type_ of the data from pythons _int_ to numpy _int32_. As far as I can tell, this is of no consequence to the rest of the code base, but please check that this is the case. From what I can find online, the only difference is that int is slightly more dynamic in that it automatically chooses a fixed-size int class (16/32/64 bit) depending on the context of the actual numbers. I do not expect any user to ever need numbers above 3294967295 for their limits, so we're probably fine by choosing int32 ourselves...

I also wrote some more detailed documentation for the sampling strategy.

closes #88 