### PR TITLE
Add noise_level_bounds to WhiteKernel

### DIFF
--- a/ProcessOptimizer/learning/gaussian_process/gpr.py
+++ b/ProcessOptimizer/learning/gaussian_process/gpr.py
@@ -132,6 +132,9 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         If set to "gaussian", then it is assumed that `y` is a noisy
         estimate of `f(x)` where the noise is gaussian.
 
+    * `noise_level_bounds` [tuple[float, float], optional (default: (1e-5,1e5))]:
+        Sets the bounds for the noise level when noise is set to "gaussian". 
+
     Attributes
     ----------
     * `X_train_` [array-like, shape = (n_samples, n_features)]:

--- a/ProcessOptimizer/learning/gaussian_process/gpr.py
+++ b/ProcessOptimizer/learning/gaussian_process/gpr.py
@@ -160,8 +160,9 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
     def __init__(self, kernel=None, alpha=1e-10,
                  optimizer="fmin_l_bfgs_b", n_restarts_optimizer=0,
                  normalize_y=False, copy_X_train=True, random_state=None,
-                 noise=None):
+                 noise=None, noise_level_bounds=(1e-5, 1e5)):
         self.noise = noise
+        self.noise_level_bounds = noise_level_bounds
         super(GaussianProcessRegressor, self).__init__(
             kernel=kernel, alpha=alpha, optimizer=optimizer,
             n_restarts_optimizer=n_restarts_optimizer,
@@ -192,7 +193,7 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
             self.kernel = ConstantKernel(1.0, constant_value_bounds="fixed") \
                           * RBF(1.0, length_scale_bounds="fixed")
         if self.noise == "gaussian":
-            self.kernel = self.kernel + WhiteKernel()
+            self.kernel = self.kernel + WhiteKernel(noise_level_bounds=self.noise_level_bounds)
         elif self.noise:
             self.kernel = self.kernel + WhiteKernel(
                 noise_level=self.noise, noise_level_bounds="fixed"

--- a/ProcessOptimizer/tests/test_gpr.py
+++ b/ProcessOptimizer/tests/test_gpr.py
@@ -62,6 +62,21 @@ def test_noise_equals_gaussian():
     assert_array_almost_equal(mean1, mean2, 4)
     assert not np.any(std1 == std2)
 
+@pytest.mark.fast_test
+def test_noise_level_bounds():
+    gpr1 = GaussianProcessRegressor(mat, noise="gaussian").fit(X, y)
+    lower1 = 1e-5
+    upper1 = 1e5
+    assert_almost_equal(gpr1.noise_level_bounds, (lower1, upper1), 6)
+    assert gpr1.noise_ >= lower1
+    assert gpr1.noise_ <= upper1
+    lower2 = 0.005
+    upper2 = 1.0
+    gpr2 = GaussianProcessRegressor(mat, noise="gaussian", noise_level_bounds=(lower2, upper2)).fit(X, y)
+    assert_almost_equal(gpr2.noise_level_bounds, (lower2, upper2), 4)
+    assert gpr2.noise_ >= lower2
+    assert gpr2.noise_ <= upper2
+    
 
 @pytest.mark.fast_test
 def test_mean_gradient():


### PR DESCRIPTION
Add the parameter noise_level_bounds to the constructor of GaussianProcessRegressor. The parameter sets the noise level bounds of the WhiteKernel used when noise is set to "gaussian". The default values are the same as the default values of the WhiteKernel constructor. 

This pull request opens up for solving the issue #95 by changing the noise level bounds. 