### PR TITLE
Fixes plot_objective for categorical variables

### DIFF
--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -622,8 +622,8 @@ def plot_objective(
     plot_options["zscale"] = zscale
     plot_options["levels"] = levels
     space = result.space
-    # Check if we have any categorical dimensions, as this will influence how 
-    # how we do the 1D plotting
+    # Check if we have any categorical dimensions, as this influences the plots
+    # on the diagonal (1D dependency)
     is_cat = [isinstance(dim, Categorical) for dim in space.dimensions]
     
     if isinstance(pars, str):
@@ -703,7 +703,7 @@ def plot_objective(
     stddev_max_2d = -float("inf")
 
     plots_data = []
-
+    # Gather all data relevant for plotting
     for i in range(space.n_dims):
         row = []
         for j in range(space.n_dims):
@@ -765,7 +765,8 @@ def plot_objective(
                     stddev_max_2d = np.max(stddevs)
 
         plots_data.append(row)
-
+    
+    # Build all the plots of in the figure
     for i in range(space.n_dims):
         for j in range(space.n_dims):
 
@@ -793,7 +794,7 @@ def plot_objective(
                         # Create one uniformly colored bar for each category.
                         # Edgecolor ensures we can see the bar when plotting 
                         # at best obeservation, as stddev is often tiny there
-                        handle = ax[i, i].bar(
+                        ax[i, i].bar(
                             xi,
                             2*1.96*stddevs,
                             width=0.2,
@@ -803,7 +804,7 @@ def plot_objective(
                             edgecolor="green",
                             zorder=1,
                         )
-                        # Also add highlight the best/expected minimum
+                        # Also add highlight the best point/expected minimum
                         ax[i, i].scatter(
                             minimum[i],
                             yi[int(minimum[i])],
@@ -887,12 +888,15 @@ def plot_objective(
                         label="Score",
                     )
                     cb.ax.locator_params(nbins=8)
+                    
                     # Add a legend for the various figure contents
                     if isinstance(pars, str):
                         if pars == "result":
                             highlight_label = "Best data point"
                         elif pars == "expected_minimum":
                             highlight_label = "Expected minimum"
+                        elif pars == "expected_minimum_random":
+                            highlight_label = "Simulated minimum"
                     # Legend icon for data points
                     legend_data_point = mpl.lines.Line2D(
                         [],

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -897,6 +897,9 @@ def plot_objective(
                             highlight_label = "Expected minimum"
                         elif pars == "expected_minimum_random":
                             highlight_label = "Simulated minimum"
+                    elif isinstance(pars, list):
+                        # The case where the user specifies [x[0], x[1], ...]
+                        highlight_label = "Point: " + str(pars)
                     # Legend icon for data points
                     legend_data_point = mpl.lines.Line2D(
                         [],
@@ -930,9 +933,13 @@ def plot_objective(
                             color="green",
                             alpha=0.5,
                         )
+                        if usepartialdependence:
+                            ci_label = "Est. 95 % credibility interval"
+                        else:
+                            ci_label = "95 % credibility interval"
                         ax[0][-1].legend(
                             handles=[legend_data_point, (legend_hp, legend_hl), legend_fill],
-                            labels=["Data points", highlight_label,"95 % credibility interval"],
+                            labels=["Data points", highlight_label, ci_label],
                             loc="lower center",
                             handler_map={tuple: mpl.legend_handler.HandlerTuple(ndivide=None)},
                         )

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -494,7 +494,7 @@ def plot_objective(
     size=2,
     zscale="linear",
     dimensions=None,
-    usepartialdependence=True,
+    usepartialdependence=False,
     pars="result",
     expected_minimum_samples=None,
     title=None,
@@ -544,8 +544,8 @@ def plot_objective(
 
     * `usepartialdependence` [bool, default=false] Whether to use partial
         dependence or not when calculating dependence. If false plot_objective
-        will parse values to the dependence function,
-        defined by the pars argument
+        will parse values to the dependence function, defined by the 
+        pars argument
 
     * `pars` [str, default = 'result' or list of floats] Defines the values
     for the red

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -10,7 +10,6 @@ from matplotlib.ticker import MaxNLocator, FuncFormatter
 from scipy.optimize import OptimizeResult
 from scipy.stats.mstats import mquantiles
 from scipy.ndimage import gaussian_filter1d
-from scipy.stats import norm
 from ProcessOptimizer import expected_minimum, expected_minimum_random_sampling
 from .space import Categorical
 from .optimizer import Optimizer

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -681,16 +681,33 @@ def plot_objective(
         x_eval = x_vals
     rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
     samples, minimum, _ = _map_categories(space, result.x_iters, x_vals)
-
+    
+    # Build slightly larger plots when we have just two dimensions
+    if space.n_dims == 2:
+        size = size*1.75
+        
     fig, ax = plt.subplots(
         space.n_dims,
         space.n_dims,
         figsize=(size * space.n_dims, size * space.n_dims),
     )
-
+    
+    # Generate consistent padding for axis labels and ticks
+    l_pad = 0.7/fig.get_figwidth()
+    r_pad = 1 - l_pad
+    b_pad = 0.7/fig.get_figheight()
+    t_pad = 1 - 0.7/fig.get_figheight()
+    
+    if space.n_dims <= 3:
+        h_pad = 0.2
+        w_pad = 0.2
+    else:
+        h_pad = 0.1
+        w_pad = 0.1
+    
     fig.subplots_adjust(
-        left=0.07, right=0.95, bottom=0.07, top=0.94, hspace=0.1, wspace=0.1
-    )
+        left=l_pad, right=r_pad, bottom=b_pad, top=t_pad, hspace=h_pad, wspace=w_pad
+    )    
 
     if title is not None:
         fig.suptitle(title)
@@ -883,8 +900,8 @@ def plot_objective(
                     cb = ax[0][-1].figure.colorbar(
                         mpl.cm.ScalarMappable(norm=norm_color, cmap=plot_options["colormap"]),
                         ax=ax[0][-1],
-                        location="bottom",
-                        fraction=0.25,
+                        location="top",
+                        fraction=0.1,
                         label="Score",
                     )
                     cb.ax.locator_params(nbins=8)
@@ -940,7 +957,7 @@ def plot_objective(
                         ax[0][-1].legend(
                             handles=[legend_data_point, (legend_hp, legend_hl), legend_fill],
                             labels=["Data points", highlight_label, ci_label],
-                            loc="lower center",
+                            loc="upper center",
                             handler_map={tuple: mpl.legend_handler.HandlerTuple(ndivide=None)},
                         )
                     else:
@@ -956,7 +973,7 @@ def plot_objective(
                         ax[0][-1].legend(
                             handles=[legend_data_point, (legend_hp, legend_hl), legend_mean],
                             labels=["Data points", highlight_label, "Model mean function"],
-                            loc="lower center",
+                            loc="upper center",
                             handler_map={tuple: mpl.legend_handler.HandlerTuple(ndivide=None)},
                         )
                     


### PR DESCRIPTION
I have implemented a correct plotting of the 1D dependency plot for categoric variables (it previously treated them as continuous factors in the plot), along with a lot of small clean-up and extra documentation including:

- Ensuring categoric labels are not removed from the axes of the 2D plots
- Rotating the x-axis labels above the diagonal plots, so longer tick labels (like 0.12) no longer overlap
- Added slightly more padding for axis labels at the top and bottom of the figure
- Implemented colorbars for 95 % credibility interval for each categoric value, reflecting how we treat confidence for the continuous 1D plots
- Changed the color of the 1D plots from angry red to friendly green
- Removed plotting of the mean function when showing confidence, to nudge users away taking the highest probability as gospel
- Added the desired highlighted point (best observation/expected minimum) to the bar plot
- Implemented a figure legend that explains what is data/best observation/expected minimum/credibility interval and rotated the colorbar for the 2D plots so it plays nice with the legend

An example of how all of this looks on a real data set:
![Updated plot_objective](https://user-images.githubusercontent.com/64902587/198032604-3ea4f622-e2dc-44e8-abbc-be1c8e0cac25.png)
