### PR TITLE
Fix#180

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -41,6 +41,14 @@ class Optimizer(object):
 
     Use this class directly if you want to control the iterations of your
     bayesian optimisation loop.
+    
+    In default behavior, the optimizer will reset the modelled experimental
+    noise between each refitting (read: while adding new data). This is
+    described in Rasmussen and Williams chapter 2. 
+    Some users might want to plot, predict or sample from a model that includes
+    the modelling of the experimental noise: in that case, two helper methods
+    can "switch" the noise "on/off". Functions are called 'add_modelled_noise'
+    and 'remove_modelled_noise'.
 
     Parameters
     ----------

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -1188,7 +1188,6 @@ class Optimizer(object):
         white_present, white_param = _param_for_white_kernel_in_Sum(self.models[-1].kernel_)
         if white_present:
             self.models[-1].kernel_.set_params(**{white_param: WhiteKernel(noise_level=noise_estimate)})
-        return self
     
     def remove_modelled_noise(self):
         '''
@@ -1202,4 +1201,4 @@ class Optimizer(object):
         white_present, white_param = _param_for_white_kernel_in_Sum(self.models[-1].kernel_)
         if white_present:
             self.models[-1].kernel_.set_params(**{white_param: WhiteKernel(noise_level=0.0)})
-        return self
+    

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -11,6 +11,7 @@ from math import isclose
 from ProcessOptimizer import gp_minimize
 from ProcessOptimizer.model_systems.benchmarks import bench1, bench1_with_time
 from ProcessOptimizer.model_systems.benchmarks import branin
+from ProcessOptimizer.model_systems.model_system import ModelSystem
 from ProcessOptimizer.learning import ExtraTreesRegressor, RandomForestRegressor
 from ProcessOptimizer.learning import GradientBoostingQuantileRegressor
 from ProcessOptimizer.optimizer import Optimizer

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -379,7 +379,7 @@ def test_add_remove_modelled_noise():
     #Add moddeled experimental noise
     opt_noise = opt.copy()
     opt_noise.add_modelled_noise()
-    res_noise = opt.get_result()
+    res_noise = opt_noise.get_result()
     _, [_, res_std_white] = expected_minimum(res_noise,
                                                      return_std=True)
     #Test modelled noise is added and predicts know noise within tolerance 10%

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -346,21 +346,24 @@ def test_add_remove_modelled_noise():
     # Set noise and model system
     noise_size = 0.45
     flat_space = [(-1.0, 1.0)]
-    flat_noise = {"model_type": "constant",
-                  "noise_size": noise_size,
-                  }
+    flat_noise = {
+        "model_type": "constant",
+        "noise_size": noise_size,
+        }
     # Build ModelSystem object
-    model = ModelSystem(score=flat_score,
-                        space=flat_space,
-                        noise_model=flat_noise,
-                        )
+    model = ModelSystem(
+        score=flat_score,
+        space=flat_space,
+        noise_model=flat_noise,
+        )
     # Instantiate Optimizer
-    opt = Optimizer(flat_space,
-                    "GP",
-                    lhs=False,
-                    n_initial_points=1,
-                    random_state=42
-                    )
+    opt = Optimizer(
+        flat_space,
+        "GP",
+        lhs=False,
+        n_initial_points=1,
+        random_state=42
+        )
     #Make 20 dispersed points on X
     next_x = np.linspace(-1, 1, 20).tolist()
     x = []

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -372,19 +372,20 @@ def test_add_remove_modelled_noise():
             y.append(model.get_score([xx]))
     # Fit the model
     res = opt.tell(x,y)
-    res_x, [res_y, res_std_no_white] = expected_minimum(res, return_std=True)
+    _, [_, res_std_no_white] = expected_minimum(res, return_std=True)
     #Add moddeled experimental noise
-    opt.add_modelled_noise()
+    opt_noise = opt.copy()
+    opt_noise.add_modelled_noise()
     res_noise = opt.get_result()
-    res_x, [res_y, res_std_white] = expected_minimum(res_noise,
+    _, [_, res_std_white] = expected_minimum(res_noise,
                                                      return_std=True)
     #Test modelled noise is added and predicts know noise within tolerance 10%
     assert res_std_no_white < res_std_white
     assert isclose (noise_size, res_std_white, rel_tol=0.1)
     #Test function to remove experimental noise and regain "old" noise level
-    opt.remove_modelled_noise()
-    res_noise = opt.get_result()
-    res_x, [res_y, res_std_reset] = expected_minimum(res_noise,
+    opt_noise.remove_modelled_noise()
+    res_noise = opt_noise.get_result()
+    _, [_, res_std_reset] = expected_minimum(res_noise,
                                                     return_std=True)
     assert isclose(res_std_no_white, res_std_reset, rel_tol=0.001)
     


### PR DESCRIPTION
This is an attempt to allow users to add or remove the modelled experimental noise. I'm balancing between not wanting to change the "inner mechanics" of our fitting while also wanting to expose the knowledge of the experimental noise to the user. Currently, experimental noise is set to zero between each iteration with reference to chapter 2 in Rasmussen and Williams. [Link.](http://www.gaussianprocess.org/gpml/chapters/RW2.pdf) 
With this "fix" the workflow could now be:

- set up optimizer
- experiment/make data/fit model (i.e. `tell()`)
- Decide on users interest in looking at the Expectation values of the model (like looking at a linear regression line) or looking at the possible outcomes of a new experiment
- If interested in "normal regression": continue
- if interested in plotting, predicting, sampling with expected noise, then call a helper function to change the noise level AND THEN call the plotting function
- Lastly: If the user wants to keep on experimenting, then `ask()` (a.k.a. 'next_x') has already been stored and is ready to be served to the user.

So in total: the user will need to call `opt.add_modelled_noise()` to go from regression to prediction and would need to call `opt.remove_modelled_noise()` to return old functionality. Alternative, the user will just need to add one additional datapoint to return to old functionality/behaviour.