### PR TITLE
fix: Removing `max_features="auto"`

### DIFF
--- a/ProcessOptimizer/learning/forest.py
+++ b/ProcessOptimizer/learning/forest.py
@@ -187,7 +187,7 @@ class RandomForestRegressor(_sk_RandomForestRegressor):
 
     def __init__(self, n_estimators=10, criterion='squared_error', max_depth=None,
                  min_samples_split=2, min_samples_leaf=1,
-                 min_weight_fraction_leaf=0.0, max_features='auto',
+                 min_weight_fraction_leaf=0.0, max_features=1.0,
                  max_leaf_nodes=None, bootstrap=True, oob_score=False,
                  n_jobs=1, random_state=None, verbose=0, warm_start=False,
                  min_variance=0.0):
@@ -372,7 +372,7 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
 
     def __init__(self, n_estimators=10, criterion='squared_error', max_depth=None,
                  min_samples_split=2, min_samples_leaf=1,
-                 min_weight_fraction_leaf=0.0, max_features='auto',
+                 min_weight_fraction_leaf=0.0, max_features=1.0,
                  max_leaf_nodes=None, bootstrap=False, oob_score=False,
                  n_jobs=1, random_state=None, verbose=0, warm_start=False,
                  min_variance=0.0):


### PR DESCRIPTION
This behaviour has been deprecated since scikit-learn 1.1.0, and has been removed in scikit-learn 1.3.0.

I am replacing it with 1.0, which, as I read
https://scikit-learn.org/1.0/modules/generated/sklearn.ensemble.ExtraTreesRegressor.html?highlight=extratreesregressor should preserve functionality.

Please comment on whether I am right.