### PR TITLE
206 expected minimum does not respect constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Changed the result object to store information about constraints (when present).
 - Updated `expected_minimum` to make sure that the returned result location respects
- SumEquals constraints if these were used during the optimization.
+  SumEquals constraints if these were used during the optimization.
 
 ## Version 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Bugfixes
 
--
+- Changed the result object to store information about constraints (when present).
+- Updated `expected_minimum` to make sure that the returned result location respects
+ SumEquals constraints if these were used during the optimization.
 
 ## Version 0.9.0
 

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -806,7 +806,14 @@ class Optimizer(object):
                 self._next_x = self.space.inverse_transform(next_x.reshape((1, -1)))[0]
         # Pack results
 
-        return create_result(self.Xi, self.yi, self.space, self.rng, models=self.models)
+        return create_result(
+            self.Xi,
+            self.yi,
+            self.space,
+            self.rng,
+            models=self.models,
+            constraints=self._constraints,
+        )
 
     def _check_y_is_valid(self, x, y):
         """Check if the shape and types of x and y are consistent."""
@@ -865,7 +872,14 @@ class Optimizer(object):
             x = self.ask()
             self.tell(x, func(x))
 
-        return create_result(self.Xi, self.yi, self.space, self.rng, models=self.models)
+        return create_result(
+            self.Xi,
+            self.yi,
+            self.space,
+            self.rng,
+            models=self.models,
+            constraints=self._constraints,
+        )
 
     def set_constraints(self, constraints):
         """Sets the constraints for the optimizer
@@ -914,7 +928,14 @@ class Optimizer(object):
         but without calling tell.
         In the case of multiobejective optimization, a list of results are
         returned."""
-        return create_result(self.Xi, self.yi, self.space, self.rng, models=self.models)
+        return create_result(
+            self.Xi,
+            self.yi,
+            self.space,
+            self.rng,
+            models=self.models,
+            constraints=self._constraints
+        )
 
     def _check_length_scale_bounds(self, dimensions, bounds):
         """Checks if length scale bounds are of in correct format"""

--- a/ProcessOptimizer/utils/utils.py
+++ b/ProcessOptimizer/utils/utils.py
@@ -272,31 +272,31 @@ def expected_minimum(
 
     xs = [res.x]
     if n_random_starts > 0:
-        if len(res.constraints.sum_equals) > 0:
-            # If the constraint is of the SumEquals type, create samples
-            # that respect this
-            xs = []
-            xs.extend(
-                res.constraints.sumequal_sampling(
-                    n_samples=n_random_starts, random_state=random_state
-                )
-            )
+        if getattr(res.constraints, "sum_equals", None):
+           # If we have a SumEquals constraint, create samples that respect it
+           xs = []
+           xs.extend(
+               res.constraints.sumequal_sampling(
+                   n_samples=n_random_starts, random_state=random_state
+                   )
+               )
         else:
-            # For all other constraints we use random sampling
+            # For all other cases (and constraints) we use random sampling
             xs.extend(res.space.rvs(n_random_starts, random_state=random_state))
     xs = res.space.transform(xs)
     best_x = None
     best_fun = np.inf
     
+    
+    cons = None
     # Prepare a linear constraint, if applicable
-    if len(res.constraints.sum_equals) > 0:
+    if getattr(res.constraints, "sum_equals", None):
         A = np.zeros((res.space.n_dims, res.space.n_dims))
         value = res.constraints.sum_equals[0].value
         for dim in res.constraints.sum_equals[0].dimensions:
             A[dim, dim] = 1
         cons = lin_constraint(A, lb=value, ub=value)
-    else:
-        cons = None
+    
             
     for x0 in xs:
         r = sp_minimize(

--- a/ProcessOptimizer/utils/utils.py
+++ b/ProcessOptimizer/utils/utils.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from functools import wraps
+from warnings import warn
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -281,6 +282,8 @@ def expected_minimum(
                    )
                )
         else:
+            if res.constraints:
+                warn.warning("Optimizer has constraints which expected_minimum() does not necessarily respect.")
             # For all other cases (and constraints) we use random sampling
             xs.extend(res.space.rvs(n_random_starts, random_state=random_state))
     xs = res.space.transform(xs)

--- a/ProcessOptimizer/utils/utils.py
+++ b/ProcessOptimizer/utils/utils.py
@@ -16,7 +16,7 @@ __all__ = (
 )
 
 
-def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
+def create_result(Xi, yi, space=None, rng=None, specs=None, models=None, constraints=None):
     """
     Initialize an `OptimizeResult` object.
 
@@ -39,6 +39,9 @@ def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
 
     * `models` [list, optional]:
         List of fit surrogate models.
+    
+    * `constraints` [Constraints object, optional]:
+        Constraints that apply to the system.
 
     Returns
     -------
@@ -61,6 +64,7 @@ def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
         res.space = space
         res.random_state = rng
         res.specs = specs
+        res.constraints = constraints
         return res
     models = np.asarray(models)
     results = []
@@ -79,6 +83,7 @@ def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
         res.space = space
         res.random_state = rng
         res.specs = specs
+        res.constraints = constraints
         results.append(res)
     return results
 


### PR DESCRIPTION
I have expanded the result object (returned by opt.tell() and opt.get_result()) to include information on constraints. This allows me to implement the second change, which is an update of expected_minimum(res) that makes it respect these constraints. I am focusing exclusively on the SumEquals constraints, since this is the case where the lack of respect for constraints becomes very visible when asking for the location of the best solution.

Still to-do: Write additional tests for the result object and expected_minimum functions.

Closes #206 #80 