### PR TITLE
WIP: Remove local calculation of gradient for acq func

### DIFF
--- a/ProcessOptimizer/acquisition.py
+++ b/ProcessOptimizer/acquisition.py
@@ -5,7 +5,7 @@ from scipy.stats import norm
 
 
 def gaussian_acquisition_1D(X, model, y_opt=None, acq_func="LCB",
-                            acq_func_kwargs=None, return_grad=True):
+                            acq_func_kwargs=None, return_grad=False):
     """
     A wrapper around the acquisition function that is called by fmin_l_bfgs_b.
 

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -773,7 +773,7 @@ class Optimizer(object):
                                         self.acq_func_kwargs,
                                     ),
                                     bounds=self.space.transformed_bounds,
-                                    approx_grad=False,
+                                    approx_grad=True,
                                     maxiter=20,
                                 )
                                 for x in x0

--- a/ProcessOptimizer/tests/test_acquisition.py
+++ b/ProcessOptimizer/tests/test_acquisition.py
@@ -96,7 +96,7 @@ def test_acquisition_api():
         assert_raises(ValueError, method, rng.rand(10), gpr)
 
 
-def check_gradient_correctness(X_new, model, acq_func, y_opt):
+""" def check_gradient_correctness(X_new, model, acq_func, y_opt):
     analytic_grad = gaussian_acquisition_1D(X_new, model, y_opt, acq_func)[1]
 
     def num_grad_func(x):
@@ -118,7 +118,7 @@ def test_acquisition_gradient():
     gpr.fit(X, y)
 
     for acq_func in ["LCB", "PI", "EI"]:
-        check_gradient_correctness(X_new, gpr, acq_func, np.max(y))
+        check_gradient_correctness(X_new, gpr, acq_func, np.max(y)) """
 
 
 def test_gaussian_acquisition_check_inputs():


### PR DESCRIPTION
To be able to seamlessly add new acq functions, it will be a lot easier if we don't calculate gradients locally. Instead the minimization of the acq-funct (using scipy fmin_l_bfgs_b) is allowed to approximate the gradients.