### PR TITLE
Opt estimate

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -850,7 +850,7 @@ class Optimizer(object):
             List of estimations with the same length as `x`. Each element has
             a field per objective of the optimizer named after the objectives
             ("Y" or "Y1", "Y2",... by default). Each objective field contains
-            a single objective estimateion with field names "mean" and "std".
+            a single objective estimation with field names "mean" and "std".
             For single objective optimizers, the estimation have the fields
             "mean" and "std", and a field with the same name as the objective
             ("Y" by default), which in turn has the fields "mean" and "std".

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -45,9 +45,9 @@ class Optimizer(object):
     noise between each refitting (read: while adding new data). This is
     described in Rasmussen and Williams chapter 2.
     Some users might want to plot, predict or sample from a model that includes
-    the modelling of the experimental noise: in that case, two helper methods
-    can "switch" the noise "on/off". Functions are called 'add_modelled_noise'
-    and 'remove_modelled_noise'.
+    the modelling of the observational noise: in that case, two helper methods
+    can "switch" the noise "on/off". Functions are called 'add_observational_noise'
+    and 'remove_observational_noise'.
 
     Parameters
     ----------
@@ -1256,6 +1256,12 @@ class Optimizer(object):
         return pop, logbook, front
 
     def add_observational_noise(self):
+        """
+        This method will add the noise that has been modelled to fit the data.
+        (The noise is disabled by default to reflect description in book on
+        gaussian processes for Machine Learning. This has been described in
+        Eq 2.24 of http://www.gaussianprocess.org/gpml/chapters/RW2.pdf)
+        """
         if self.n_objectives > 1:
             for model in self.models[-1]:
                 self.add_observational_noise_single_model(model)
@@ -1264,12 +1270,6 @@ class Optimizer(object):
 
     # This function adds the modelled white noise to the regressor to allow predictions including noise
     def add_observational_noise_single_model(self, model):
-        """
-        This method will add the noise that has been modelled to fit the data. (The noise is disabled
-        by default to reflect description in book on gaussian processes for Machine Learning
-        This has been described in Eq 2.24 of
-        http://www.gaussianprocess.org/gpml/chapters/RW2.pdf)
-        """
         if (
             isinstance(model.noise, str)
             and model.noise != "gaussian"
@@ -1287,6 +1287,11 @@ class Optimizer(object):
             )
 
     def remove_observational_noise(self):
+        """
+        This method resets the noise levels to only include the "true"
+        uncertaincy of the main kernel used for fitting and predicting. This
+        method can be used in conjunction with the 'add_modelled_noise()'
+        """
         if self.n_objectives > 1:
             for model in self.models[-1]:
                 self.remove_observational_noise_single_model(model)
@@ -1294,11 +1299,6 @@ class Optimizer(object):
             self.remove_observational_noise_single_model(self.models[-1])
 
     def remove_observational_noise_single_model(self, model):
-        """
-        This method resets the noise levels to only include the "true" uncertaincy of the main kernel
-        used for fitting and predicting. This method can be used in conjunction with the
-        'add_modelled_noise()'
-        """
         if (
             isinstance(model.noise, str)
             and model.noise != "gaussian"

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -1238,8 +1238,15 @@ class Optimizer(object):
 
         return pop, logbook, front
 
+    def add_observational_noise(self):
+        if self.n_objectives > 1:
+            for model in self.models[-1]:
+                self.add_observational_noise_single_model(model)
+        else:
+            self.add_observational_noise_single_model(self.models[-1])
+
     # This function adds the modelled white noise to the regressor to allow predictions including noise
-    def add_modelled_noise(self):
+    def add_observational_noise_single_model(self, model):
         """
         This method will add the noise that has been modelled to fit the data. (The noise is disabled
         by default to reflect description in book on gaussian processes for Machine Learning
@@ -1247,38 +1254,45 @@ class Optimizer(object):
         http://www.gaussianprocess.org/gpml/chapters/RW2.pdf)
         """
         if (
-            isinstance(self.models[-1].noise, str)
-            and self.models[-1].noise != "gaussian"
+            isinstance(model.noise, str)
+            and model.noise != "gaussian"
         ):
             raise ValueError(
-                "Expected noise to be 'gaussian', got %s" % self.models[-1].noise
+                "Expected noise to be 'gaussian', got %s" % model.noise
             )
-        noise_estimate = self.models[-1].noise_
+        noise_estimate = model.noise_
         white_present, white_param = _param_for_white_kernel_in_Sum(
-            self.models[-1].kernel_
+            model.kernel_
         )
         if white_present:
-            self.models[-1].kernel_.set_params(
+            model.kernel_.set_params(
                 **{white_param: WhiteKernel(noise_level=noise_estimate)}
             )
 
-    def remove_modelled_noise(self):
+    def remove_observational_noise(self):
+        if self.n_objectives > 1:
+            for model in self.models[-1]:
+                self.remove_observational_noise_single_model(model)
+        else:
+            self.remove_observational_noise_single_model(self.models[-1])
+
+    def remove_observational_noise_single_model(self, model):
         """
         This method resets the noise levels to only include the "true" uncertaincy of the main kernel
         used for fitting and predicting. This method can be used in conjunction with the
         'add_modelled_noise()'
         """
         if (
-            isinstance(self.models[-1].noise, str)
-            and self.models[-1].noise != "gaussian"
+            isinstance(model.noise, str)
+            and model.noise != "gaussian"
         ):
             raise ValueError(
-                "expected noise to be 'gaussian', got %s" % self.models[-1].noise
+                "expected noise to be 'gaussian', got %s" % model.noise
             )
         white_present, white_param = _param_for_white_kernel_in_Sum(
-            self.models[-1].kernel_
+            model.kernel_
         )
         if white_present:
-            self.models[-1].kernel_.set_params(
+            model.kernel_.set_params(
                 **{white_param: WhiteKernel(noise_level=0.0)}
             )

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -907,9 +907,10 @@ class Optimizer(object):
             # list of tuples, each tuple containing two arrays, one for the
             # mean and one for the standard deviation; each array has one
             # element per x.
-            predict_list = [model.predict(transformed_x, return_std=True) for
-                            model in self_with_observation_noise.models[-1]
-                            ]
+            predict_list = [
+                model.predict(transformed_x, return_std=True) for
+                model in self_with_observation_noise.models[-1]
+            ]
             noiseless_predict_list = [
                 model.predict(transformed_x, return_std=True) for
                 model in self_without_observation_noise.models[-1]

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -851,7 +851,7 @@ class Optimizer(object):
             a field per objective of the optimizer named after the objectives
             ("Y" or "Y1", "Y2",... by default). Each objective field contains
             a single objective estimation with field names "mean" and "std".
-            For single objective optimizers, the estimation have the fields
+            For single objective optimizers, the estimation has the fields
             "mean" and "std", and a field with the same name as the objective
             ("Y" by default), which in turn has the fields "mean" and "std".
         """

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -176,7 +176,7 @@ class Optimizer(object):
         acq_func_kwargs=None,
         acq_optimizer_kwargs=None,
         n_objectives=1,
-        objective_name_list: List[str]=None,
+        objective_name_list: List[str] = None,
     ):
         self.rng = check_random_state(random_state)
 

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -847,7 +847,7 @@ class Optimizer(object):
         Returns
         -------
         * `y` [list[namedtuple]]:
-            List of estimations with the same length as `x`. Each element have
+            List of estimations with the same length as `x`. Each element has
             a field per objective of the optimizer named after the objectives
             ("Y" or "Y1", "Y2",... by default). Each objective field contains
             a single objective estimateion with field names "mean" and "std".

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -469,6 +469,24 @@ def test_estimate_single_x():
 
 
 @pytest.mark.fast_test
+def test_estimate_uncertainty():
+    x = [1, 1]
+    regressor = GaussianProcessRegressor(noise=1)
+    opt = Optimizer(
+        [(-2.0, 2.0), (-3.0, 3.0)],
+        base_estimator=regressor,
+        n_initial_points=1,
+    )
+    opt.tell(x, 2)
+    estimate_list = opt.estimate(x)[0]
+    assert_almost_equal(estimate_list.Y.std, (1/2)**(1/2))
+    # Why is the expected value 1, and not 2, and why is the standard
+    # deviation sqrt(1/2)? This would be the case if there were two
+    # observations, one with Y = 0, and one with Y = 2. Is that what
+    # GaussianProcessRegressor does if there is noise and only one observation?
+
+
+@pytest.mark.fast_test
 def test_estimate_multiple_x():
     x_list = [[1, 1], [0, 0], [1, -1]]
     y_list = [2, -1, 5]

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -505,7 +505,19 @@ def test_estimate_multiple_y():
 
 
 @pytest.mark.fast_test
-def test_named_objectives():
+def test_estimate_named_objective():
+    opt = Optimizer(
+        [(-2.0, 2.0), (-3.0, 3.0)],
+        n_initial_points=1,
+        objective_name_list=["foo"]
+    )
+    opt.tell([1, 1], 2)
+    assert_almost_equal(opt.estimate([1, 1])[0].foo.mean, 2)
+    assert_almost_equal(opt.estimate([1, 1])[0].mean, 2)
+
+
+@pytest.mark.fast_test
+def test_estimate_named_objectives():
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
         n_initial_points=1,

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -410,7 +410,7 @@ def test_iterating_ask_tell_lhs():
 def test_add_remove_observational_noise():
     """
     Tests whether the addition of white noise leads to predictions closer to
-    known true values of experimental noise (iid gaussian noise)"""
+    known true values of observational noise (iid gaussian noise)"""
 
     # Define objective function
     def flat_score(x):
@@ -436,7 +436,7 @@ def test_add_remove_observational_noise():
     # Fit the model
     res = opt.tell(x, y)
     _, [_, res_std_no_white] = expected_minimum(res, return_std=True)
-    # Add moddeled experimental noise
+    # Add moddeled observational noise
     opt_noise = opt.copy()
     opt_noise.add_observational_noise()
     res_noise = opt_noise.get_result()
@@ -444,7 +444,7 @@ def test_add_remove_observational_noise():
     # Test observational noise is added and predicts know noise within tolerance 10%
     assert res_std_no_white < res_std_white
     assert isclose(noise_size, res_std_white, rel_tol=0.1)
-    # Test function to remove experimental noise and regain "old" noise level
+    # Test function to remove observational noise and regain "old" noise level
     opt_noise.remove_observational_noise()
     res_noise = opt_noise.get_result()
     _, [_, res_std_reset] = expected_minimum(res_noise, return_std=True)
@@ -455,7 +455,7 @@ def test_add_remove_observational_noise():
 def test_add_remove_observational_noise_multiple_y():
     """
     Tests whether the addition of white noise leads to predictions closer to
-    known true values of experimental noise (iid gaussian noise)"""
+    known true values of observational noise (iid gaussian noise)"""
 
     # Define objective function
     def flat_score(x):
@@ -483,7 +483,7 @@ def test_add_remove_observational_noise_multiple_y():
     res_std_no_white = [None]*opt.n_objectives  # Initializing list with a position per objective
     for i, res in enumerate(res_list):
         _, [_, res_std_no_white[i]] = expected_minimum(res, return_std=True)
-    # Add moddeled experimental noise
+    # Add moddeled observational noise
     opt_noise = opt.copy()
     opt_noise.add_observational_noise()
     res_noise = opt_noise.get_result()
@@ -491,7 +491,7 @@ def test_add_remove_observational_noise_multiple_y():
         _, [_, res_std_white] = expected_minimum(result, return_std=True)
         assert res_std_no_white[i] < res_std_white
         assert isclose(noise_size, res_std_white, rel_tol=0.1)
-    # Test function to remove experimental noise and regain "old" noise level
+    # Test function to remove observational noise and regain "old" noise level
     opt_noise.remove_observational_noise()
     res_noise = opt_noise.get_result()
     for i, result in enumerate(res_noise):

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -440,3 +440,12 @@ def test_add_remove_modelled_noise():
     res_noise = opt_noise.get_result()
     _, [_, res_std_reset] = expected_minimum(res_noise, return_std=True)
     assert isclose(res_std_no_white, res_std_reset, rel_tol=0.001)
+
+
+@pytest.mark.fast_test
+def test_predict_single_value():
+    opt = Optimizer([(-2.0, 2.0), (-3.0, 3.0)])
+    for x1 in np.linspace(-2.0, 2.0, 10):
+        for x2 in np.linspace(-3.0, 3.0, 20):
+            opt.tell([x1, x2], x1+x2)
+    X = opt.predict([[1, 1], [0, 0]])

--- a/ProcessOptimizer/tests/test_optimizer.py
+++ b/ProcessOptimizer/tests/test_optimizer.py
@@ -451,42 +451,47 @@ def test_add_remove_modelled_noise():
 
 @pytest.mark.fast_test
 def test_estimate_single_x():
+    x = [1, 1]
     regressor = GaussianProcessRegressor(noise=0, alpha=0)
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
         base_estimator=regressor,
         n_initial_points=1,
     )
-    opt.tell([1, 1], 2)
-    X = opt.estimate([1, 1])[0]
-    assert_almost_equal(X.Y.mean, 2)
-    assert_almost_equal(X[0].mean, 2)  # test that indexing works
-    assert_almost_equal(X.Y.std, 0)
-    assert_almost_equal(X.mean, 2)
-    assert_almost_equal(X[1], 2)  # test that indexing works
-    assert_almost_equal(X.std, 0)
+    opt.tell(x, 2)
+    estimate_list = opt.estimate(x)[0]
+    assert_almost_equal(estimate_list.Y.mean, 2)
+    assert_almost_equal(estimate_list[0].mean, 2)  # test that indexing works
+    assert_almost_equal(estimate_list.Y.std, 0)
+    assert_almost_equal(estimate_list.mean, 2)
+    assert_almost_equal(estimate_list[1], 2)  # test that indexing works
+    assert_almost_equal(estimate_list.std, 0)
 
 
 @pytest.mark.fast_test
 def test_estimate_multiple_x():
+    x_list = [[1, 1], [0, 0], [1, -1]]
+    y_list = [2, -1, 5]
     regressor = GaussianProcessRegressor(noise=0, alpha=0)
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
         base_estimator=regressor,
         n_initial_points=3,
     )
-    opt.tell([[1, 1], [0, 0], [1, -1]], [2, -1, 5])
-    X = opt.estimate([[1, 1], [0, 0], [1, -1]])
-    assert_almost_equal(X[0].Y.mean, 2)
-    assert_almost_equal(X[0].mean, 2)
-    assert_almost_equal(X[1].Y.mean, -1)
-    assert_almost_equal(X[1].mean, -1)
-    assert_almost_equal(X[2].Y.mean, 5)
-    assert_almost_equal(X[2].mean, 5)
+    opt.tell(x_list, y_list)
+    etimate_list = opt.estimate(x_list)
+    assert_almost_equal(etimate_list[0].Y.mean, y_list[0])
+    assert_almost_equal(etimate_list[0].mean, y_list[0])
+    assert_almost_equal(etimate_list[1].Y.mean, y_list[1])
+    assert_almost_equal(etimate_list[1].mean, y_list[1])
+    assert_almost_equal(etimate_list[2].Y.mean, y_list[2])
+    assert_almost_equal(etimate_list[2].mean, y_list[2])
 
 
 @pytest.mark.fast_test
 def test_estimate_multiple_y():
+    x_list = [[1, 1], [0, 0], [1, -1]]
+    y_list = [[2, 2], [-1, 0], [-3, 5]]
     regressor = GaussianProcessRegressor(noise=0, alpha=0)
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
@@ -494,37 +499,42 @@ def test_estimate_multiple_y():
         n_initial_points=3,
         n_objectives=2
     )
-    opt.tell([[1, 1], [0, 0], [1, -1]], [[2, 2], [-1, 0], [-3, 5]])
-    X = opt.estimate([[1, 1], [0, 0], [1, -1]])
-    assert_almost_equal(X[0].Y1.mean, 2)
-    assert_almost_equal(X[0].Y2.mean, 2)
-    assert_almost_equal(X[1].Y1.mean, -1)
-    assert_almost_equal(X[1].Y2.mean, 0)
-    assert_almost_equal(X[2].Y1.mean, -3)
-    assert_almost_equal(X[2].Y2.mean, 5)
+    opt.tell(x_list, y_list)
+    estimate_list = opt.estimate(x_list)
+    assert_almost_equal(estimate_list[0].Y1.mean, y_list[0][0])
+    assert_almost_equal(estimate_list[0].Y2.mean, y_list[0][1])
+    assert_almost_equal(estimate_list[1].Y1.mean, y_list[1][0])
+    assert_almost_equal(estimate_list[1].Y2.mean, y_list[1][1])
+    assert_almost_equal(estimate_list[2].Y1.mean, y_list[2][0])
+    assert_almost_equal(estimate_list[2].Y2.mean, y_list[2][1])
 
 
 @pytest.mark.fast_test
 def test_estimate_named_objective():
+    x = [1, 1]
+    y = 2
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
         n_initial_points=1,
         objective_name_list=["foo"]
     )
-    opt.tell([1, 1], 2)
-    assert_almost_equal(opt.estimate([1, 1])[0].foo.mean, 2)
-    assert_almost_equal(opt.estimate([1, 1])[0].mean, 2)
+    opt.tell(x, y)
+    estimate = opt.estimate(x)[0]
+    assert_almost_equal(estimate.foo.mean, y)
+    assert_almost_equal(estimate.mean, y)
 
 
 @pytest.mark.fast_test
 def test_estimate_named_objectives():
+    x = [1, 1]
+    y = [2, -2]
     opt = Optimizer(
         [(-2.0, 2.0), (-3.0, 3.0)],
         n_initial_points=1,
         n_objectives=2,
         objective_name_list=["foo", "bar"]
     )
-    opt.tell([[1, 1]], [[2, 2]])
-    X = opt.estimate([1, 1])[0]
-    assert_almost_equal(X.foo.mean, 2)
-    assert_almost_equal(X.bar.mean, 2)
+    opt.tell([x], [y])
+    estimate = opt.estimate(x)[0]
+    assert_almost_equal(estimate.foo.mean, y[0])
+    assert_almost_equal(estimate.bar.mean, y[1])


### PR DESCRIPTION
2024-02-29: I have added model noise, so std is the uncertainty on the next observation, while std_model is the uncertainty in the mean of many observations.

Implementing estimate() in optimizer.

It is similar to the predict() in regressors, but the format of the returned value is different enough to warrant a different name:

The predictions are a tuple of two arrays, one for the mean and one for the standard deviation; each array has one element per parameter combination. So roughly ([mean1, mean2, ...], [std1, std2, ...])

The estimate is a list of namedtuples. The names tuples has a field per objective. Each filed contains a namedtuple with two fields, one for the mean and one for the standard deviation; each list element corresponds to one parameter combination.

As an example:
```
[
    estimation(Y1=single_objective_estimation(mean=2.0, std=0.0, std_model=0.0), Y2=single_objective_estimation(mean=2.0, std=0.0, std_model=0.0)),
    estimation(Y1=single_objective_estimation(mean=-1.0, std=0.0, std_model=0.0), Y2=single_objective_estimation(mean=0.0, std=0.0, std_model=0.0)),
    estimation(Y1=single_objective_estimation(mean=-3.0, std=0.0, std_model=0.0), Y2=single_objective_estimation(mean=5.0, std=0.0, std_model=0.0))
]
```

For single objective optimizers, I have added a bit of ease of use, while still keeping the consistency:

```
[
    estimation(Y=single_objective_estimation(mean=2.0, std=0.0, std_model=0.0), mean=2.0, std=0.0, std_model=0.0), 
    estimation(Y=single_objective_estimation(mean=-1.0, std=0.0, std_model=0.0), mean=-1.0, std=0.0, std_model=0.0),
    estimation(Y=single_objective_estimation(mean=5.0, std=0.0, std_model=0.0), mean=5.0, std=0.0, std_model=0.0)
]
```

so you can go `X[0].mean`, or `X[0].Y.mean`.

To make this work, I also introduce names for objectives. This will be useful when making Pareto plots.