### PR TITLE
Fix #237Add warning that constraints are not implemented for multiobjective optimization (also "fix" stbr and constraints)

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -408,6 +408,28 @@ class Optimizer(object):
         if not ((isinstance(n_points, int) and n_points > 0) or n_points is None):
             raise ValueError("n_points should be int > 0, got " + str(n_points))
         # These are the only filling strategies which are supported
+        
+        if strategy == "stbr_full" and self._n_initial_points < 1:
+            # Steienerberger sampling can not be used from an empty Xi set
+            if self.Xi == []:
+                raise ValueError(
+                    "Steinerberger sampling requires initial points but got [] "
+                )
+
+            if n_points is None:
+                # Returns a single Steinerberger point
+                X = self.stbr_scipy()
+            else:
+                # Returns 'n_points' Steinerberger points
+                X = self.stbr_scipy(n_points=n_points)
+            return X
+        
+        if n_points is None or n_points == 1:
+            return self._ask()
+        
+        # The following assertions deal with cases in which the user asks for more than
+        # single experiments
+        
         supported_strategies = [
             "cl_min",
             "cl_mean",
@@ -424,25 +446,12 @@ class Optimizer(object):
                 + ", "
                 + "got %s" % strategy
             )
-
-        if strategy == "stbr_full" and self._n_initial_points < 1:
-            # Steienerberger sampling can not be used from an empty Xi set
-            if self.Xi == []:
-                raise ValueError(
-                    "Steinerberger sampling requires initial points but got [] "
-                )
-
-            if n_points is None:
-                # Returns a single Steinerberger point
-                X = self.stbr_scipy()
-            else:
-                # Returns 'n_points' Steinerberger points
-                X = self.stbr_scipy(n_points=n_points)
-            return X
-
-        if n_points is None or n_points == 1:
-            return self._ask()
-
+        
+        if strategy in ["stbr_fill", "stbr_full"] and self.get_constraints() is not None:
+            raise ValueError(
+                "Steinerberger (default setting) sampling can not be used with constraints,\
+                try using another strategy like 'opt.ask(n,strategy='cl_min')'"
+            )
         # Caching the result with n_points not None. If some new parameters
         # are provided to the ask, the cache_ is not used.
         if (n_points, strategy) in self.cache_:

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -889,11 +889,19 @@ class Optimizer(object):
         * `constraints` [list] or [Constraints]:
             Can either be a list of Constraint objects or a Constraints object
         """
+                
+        if self.n_objectives > 1:
+            raise RuntimeError(
+            "Can't set constraints for multiobjective optimization. The NSGA-II algorithm \
+            used for multiobjective optimization does not support constraints."
+            )
+            
         if self._n_initial_points > 0 and self._lhs:
             raise RuntimeError(
-                "Can't set constraints while latin hypercube sampling points are not exhausted."
+                "Can't set constraints while latin hypercube sampling points are not exhausted.\
+                Consider reinitialising the optimizer with lhs=False as argument."
             )
-
+            
         if constraints:
             if isinstance(constraints, Constraints):
                 # If constraints is a Constraints object we simply add it

--- a/ProcessOptimizer/tests/test_constraints.py
+++ b/ProcessOptimizer/tests/test_constraints.py
@@ -939,3 +939,16 @@ def test_lhs_with_constraints():
     opt = Optimizer(space, "ET", lhs=True, n_initial_points=2)
     opt.tell([[1], [1]], [0, 0])  # Use all of the two initial points
     opt.set_constraints(cons)  # Now it should be possible to set constraints
+    
+
+@pytest.mark.fast_test
+def test_multiobjective_constraints():
+    # Test that multiobjective optimization
+    # correctly returns an error when constraints are set
+    space = Space([Real(1, 10)])
+    cons_list = [Single(0, 5.0, "real")]
+    cons = Constraints(cons_list, space)
+    opt = Optimizer(space, lhs=False, n_objectives=2)
+    with raises(RuntimeError):
+        opt.set_constraints(cons)
+

--- a/ProcessOptimizer/tests/test_utils.py
+++ b/ProcessOptimizer/tests/test_utils.py
@@ -202,7 +202,7 @@ def test_expected_minimum_respects_constraints():
     )
     constraints = [SumEquals(dimensions=[0, 1, 2], value=2)]
     opt.set_constraints(constraints)
-    x = opt.ask(3)
+    x = opt.ask(3,strategy='cl_min')
     y = [1, 2, 0]
     result = opt.tell(x, y)
     x_min, _ = expected_minimum(result, random_state=1, return_std=False)


### PR DESCRIPTION
As described in issue #237, the code does not warn the users that constraints are not applied during multiobkective optimization. The nature of NSGA-II algorithm (applied in Pareto optimization) makes it non-trivial to apply constraints. Hence, I have chosen to follow the existing concensus in "set_constraints" and raises a runtimeerror.
A test is also included