### PR TITLE
Dependabot only alerts about major releases in Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
-    assignees:
+    reviewers:
     # I can't get groups to work, so I'm just listing all the maintainers here. Not ideal, but it should work.
       - "SRFU-NN"
       - "sqbl"
@@ -17,6 +17,9 @@ updates:
     commit-message:
       # Prefix all commit messages with "[pip] " (no colon, but a trailing whitespace)
       prefix: "[pip] "
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"] # Ignore everything except major updates with semantic versioning
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -24,7 +27,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    assignees:
+    reviewers:
     # I can't get groups to work, so I'm just listing all the maintainers here. Not ideal, but it should work.
       - "SRFU-NN"
       - "sqbl"

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ setup(
         "ProcessOptimizer.learning.gaussian_process",
     ],
     install_requires=[
-        "numpy>=1.0.0",
-        "matplotlib>=1.0.0",
-        "scipy>=1.0.0",
-        "bokeh>=1.0.0",
+        "numpy",
+        "matplotlib",
+        "scipy",
+        "bokeh",
         "scikit-learn>=0.24.2",
-        "six>=1.0.0",
-        "deap>=1.0.0",
-        "pyYAML>=1.0.0",
+        "six",
+        "deap",
+        "pyYAML",
     ],
     extras_require={
         "browniebee": [


### PR DESCRIPTION
Minor (2.3.4 -> 2.4.0) and patch (2.3.4 -> 2.3.5) are ignored.

Also changed asignees to reviewers, to make everything smoother.