### PR TITLE
WIP: Allow multiple points from opt.ask() as long as we are below n_initial points

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -471,9 +471,17 @@ class Optimizer(object):
             and strategy in ["stbr_fill", "stbr_full"] 
             and self.get_constraints() is not None):
                 raise ValueError(
-                    "Steinerberger (default setting) sampling can not be used with constraints,\
-                    try using another strategy like 'opt.ask(n,strategy='cl_min')'"
+                    "Steinerberger (default setting) sampling can not be used with constraints, "
+                    + "try using another strategy like 'opt.ask(n,strategy='cl_min')'"
                 )
+        elif (strategy in ["stbr_fill", "stbr_full"]
+              and self.get_constraints() is not None):
+            warnings.warn(
+                "Steinerberger (default setting) sampling can not be used with constraints, "
+                +f"and you will get an error once you ask for more than {self._n_initial_points} new suggestions. "
+                +"Try using another strategy like 'opt.ask(n,strategy='cl_min')'"
+            )
+                
         # Caching the result with n_points not None. If some new parameters
         # are provided to the ask, the cache_ is not used.
         if (n_points, strategy) in self.cache_:

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -467,11 +467,13 @@ class Optimizer(object):
                 + "got %s" % strategy
             )
         
-        if strategy in ["stbr_fill", "stbr_full"] and self.get_constraints() is not None:
-            raise ValueError(
-                "Steinerberger (default setting) sampling can not be used with constraints,\
-                try using another strategy like 'opt.ask(n,strategy='cl_min')'"
-            )
+        if (n_points > self._n_initial_points 
+            and strategy in ["stbr_fill", "stbr_full"] 
+            and self.get_constraints() is not None):
+                raise ValueError(
+                    "Steinerberger (default setting) sampling can not be used with constraints,\
+                    try using another strategy like 'opt.ask(n,strategy='cl_min')'"
+                )
         # Caching the result with n_points not None. If some new parameters
         # are provided to the ask, the cache_ is not used.
         if (n_points, strategy) in self.cache_:

--- a/ProcessOptimizer/tests/test_constraints.py
+++ b/ProcessOptimizer/tests/test_constraints.py
@@ -245,6 +245,7 @@ def test_SumEquals():
         n_initial_points=10,
     )
     opt.set_constraints(cons)
+    # Check that we can ask for 10 points
     assert opt.ask(10)
     # We should not be able to ask for 11
     with raises(ValueError):

--- a/ProcessOptimizer/tests/test_constraints.py
+++ b/ProcessOptimizer/tests/test_constraints.py
@@ -234,6 +234,31 @@ def test_SumEquals():
     # Check that the other dimensions have correct type
     assert isinstance(samples[0][3], str)
     assert not isinstance(samples[0][2], str)
+    
+    # Test that we can ask for multiple points at a time, as long as we have 
+    # less than n_initial_points of data
+    space = Space([[0.0, 10.0], [0.0, 10.0]])
+    cons = Constraints([SumEquals((0, 1), 5)], space)
+    opt = Optimizer(
+        dimensions=space,
+        lhs=False,
+        n_initial_points=10,
+    )
+    opt.set_constraints(cons)
+    assert opt.ask(10)
+    # We should not be able to ask for 11
+    with raises(ValueError):
+        opt.ask(11)
+    # Check that we can ask for multiple experiments piecemeal up to 
+    # n_initial_points (here 10), but not after
+    for i in range(5):
+        x = opt.ask(2)
+        y = [2, 2]
+        opt.tell(x, y)
+    with raises(ValueError):
+        opt.ask(2)
+    
+    
 
 @pytest.mark.fast_test
 def test_Conditional():


### PR DESCRIPTION
Implemented a fix that allows constrained optimization problems to return more than one next point in opt.ask(), as long as we have not exhausted the initial list of points defined when building the optimizer.

closes #254 