### PR TITLE
Fixes interaction between constrained dimensions and categorical factors with 2+ levels

### DIFF
--- a/ProcessOptimizer/utils/utils.py
+++ b/ProcessOptimizer/utils/utils.py
@@ -294,7 +294,7 @@ def expected_minimum(
     cons = None
     # Prepare a linear constraint, if applicable
     if hasattr(res.constraints, "sum_equals"):
-        A = np.zeros((1, res.space.n_dims))
+        A = np.zeros((1, res.space.transformed_n_dims))
         value = res.constraints.sum_equals[0].value
         for dim in res.constraints.sum_equals[0].dimensions:
             # Normalization rescales the ratio that the constrained dimensions 


### PR DESCRIPTION
The way categorical dimensions with many levels are handled in their transformed spaces had an unintended bad interaction with the way we choose values in constrained spaces. The fix is simple as it only involves one line of code.

closes #255 