### PR TITLE
Updates for 0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,27 @@
 # Release history
 
-## Version 0.9.5 [unpublished]
+## Version 0.9.6 [unpublished]
 
 ### Changes
 
--
+- 
 
 ### Bugfixes
 
--
+- 
+
+## Version 0.9.5
+
+### Changes
+
+- Updated package requirements for Brownie Bee user interface.
+
+### Bugfixes
+
+- Fix that categorical dimensions with more than two levels induces error when used 
+  together with SumEqual constraint.
+- Fix that Bokeh has changed naming convention related to sizes of circles in their
+  plots from "size" to "radius".
 
 ## Version 0.9.4
 

--- a/setup.py
+++ b/setup.py
@@ -39,15 +39,14 @@ setup(
     ],
     extras_require={
         "browniebee": [
-            "bokeh==3.1.1",
+            "bokeh==3.4.1",
             "deap==1.4.1",
-            "matplotlib==3.7.2",
-            "numpy==1.24.4",
+            "matplotlib==3.8.4",
+            "numpy==1.26.4",
             "pyYAML==6.0.1",
-            "scikit-learn==1.3.0",
-            "scipy==1.10.1",
+            "scikit-learn==1.4.2",
+            "scipy==1.13.0",
             "six==1.16.0",
-            "tornado==6.3.3",
         ]
     },
     long_description=long_description,


### PR DESCRIPTION
I've updated the changelog to make us ready for 0.9.5, and updated the package requirements for the Brownie Bee extras. Incidentally, this may fix the issues observed with tests in python 3.12 for Brownie Bee.

Once approved, will you bump version number to 0.9.5 and update pip?