### PR TITLE
Setting noise size on ZeroNoise now raises error

### DIFF
--- a/ProcessOptimizer/model_systems/noise_models.py
+++ b/ProcessOptimizer/model_systems/noise_models.py
@@ -172,6 +172,15 @@ class ZeroNoise(NoiseModel):
     def get_noise(self, _, Y: float) -> float:
         return 0
 
+    @property
+    def noise_size(self):
+        return 0
+
+    @noise_size.setter
+    def noise_size(self, value):
+        if value != 0:
+            raise ValueError("ZeroNoise should not have a noise size other than 0.")
+
 
 class SumNoise(NoiseModel):
     """

--- a/ProcessOptimizer/tests/test_noise_model.py
+++ b/ProcessOptimizer/tests/test_noise_model.py
@@ -303,3 +303,11 @@ def test_noise_seed_reset():
     reset_noise = noise_model.get_noise(None, 0)
     assert first_noise == reset_noise
     assert first_noise != second_noise
+
+
+def test_zero_noise_size():
+    noise_model = ZeroNoise()
+    assert noise_model.noise_size == 0
+    noise_model.noise_size = 0
+    with pytest.raises(ValueError):
+        noise_model.noise_size = 1


### PR DESCRIPTION
ZeroNoise noise model now gives an error if its noise size is set to anything but 0