### PR TITLE
Fix warnings for optimizer at old point and dep warning for in1d

### DIFF
--- a/ProcessOptimizer/learning/gbrt.py
+++ b/ProcessOptimizer/learning/gbrt.py
@@ -110,7 +110,7 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
 
         elif return_std:
             std_quantiles = [0.16, 0.5, 0.84]
-            is_present_mask = np.in1d(std_quantiles, self.quantiles)
+            is_present_mask = np.isin(std_quantiles, self.quantiles)
             if not np.all(is_present_mask):
                 raise ValueError(
                     "return_std works only if the quantiles during "

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -431,7 +431,7 @@ class Optimizer(object):
         if not ((isinstance(n_points, int) and n_points > 0) or n_points is None):
             raise ValueError("n_points should be int > 0, got " + str(n_points))
         # These are the only filling strategies which are supported
-        
+
         if strategy == "stbr_full" and self._n_initial_points < 1:
             # Steienerberger sampling can not be used from an empty Xi set
             if self.Xi == []:
@@ -446,13 +446,13 @@ class Optimizer(object):
                 # Returns 'n_points' Steinerberger points
                 X = self.stbr_scipy(n_points=n_points)
             return X
-        
+
         if n_points is None or n_points == 1:
             return self._ask()
-        
+
         # The following assertions deal with cases in which the user asks for more than
         # single experiments
-        
+
         supported_strategies = [
             "cl_min",
             "cl_mean",
@@ -469,7 +469,7 @@ class Optimizer(object):
                 + ", "
                 + "got %s" % strategy
             )
-        
+
         if strategy in ["stbr_fill", "stbr_full"] and self.get_constraints() is not None:
             raise ValueError(
                 "Steinerberger (default setting) sampling can not be used with constraints,\
@@ -599,7 +599,9 @@ class Optimizer(object):
 
             if abs(min_delta_x) <= 1e-8:
                 warnings.warn(
-                    "The objective has been evaluated " "at this point before."
+                    "FYI: The optimizer already has information about the "
+                    "objective at this point. This can e.g., occur when the "
+                    "optimizer assesses noise and uncertainty."
                 )
 
             # return point computed from last call to tell()
@@ -1015,19 +1017,19 @@ class Optimizer(object):
         * `constraints` [list] or [Constraints]:
             Can either be a list of Constraint objects or a Constraints object
         """
-                
+
         if self.n_objectives > 1:
             raise RuntimeError(
             "Can't set constraints for multiobjective optimization. The NSGA-II algorithm \
             used for multiobjective optimization does not support constraints."
             )
-            
+
         if self._n_initial_points > 0 and self._lhs:
             raise RuntimeError(
                 "Can't set constraints while latin hypercube sampling points are not exhausted.\
                 Consider reinitialising the optimizer with lhs=False as argument."
             )
-            
+
         if constraints:
             if isinstance(constraints, Constraints):
                 # If constraints is a Constraints object we simply add it


### PR DESCRIPTION
As discussed at Nørdemøde, some clean-up to get rid of Dep warning for np.in1d -> np.isin
A more friendly warning about probing same point in space as earlier