### PR TITLE
Add classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,21 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.6"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules"
+]
 dependencies = [
     "numpy",
     "matplotlib",


### PR DESCRIPTION
One could add another entry in the list of classifiers, like, "Topic :: Scientific/Engineering :: Chemistry" to highlight the practical applications of this package. However, the package is broadly applicable, why I suggest just having: "Topic :: Scientific/Engineering"