### PR TITLE
Fix sanitize names for patsy

### DIFF
--- a/ProcessOptimizer/samplers/doe/doe_utils.py
+++ b/ProcessOptimizer/samplers/doe/doe_utils.py
@@ -109,8 +109,8 @@ def sanitize_names_for_patsy(factor_names):
         "~",
     ]
     chars_to_remove = ["$", "(", ")", "[", "]", "{", "}"]
-
-    sanitized_factor_names = factor_names[:]
+    # Copy the list to avoid changing the input
+    sanitized_factor_names = factor_names.copy()
     for i, name in enumerate(sanitized_factor_names):
         for symbol in chars_to_replace_with_underscore:
             if symbol in name:

--- a/ProcessOptimizer/samplers/doe/doe_utils.py
+++ b/ProcessOptimizer/samplers/doe/doe_utils.py
@@ -110,7 +110,8 @@ def sanitize_names_for_patsy(factor_names):
     ]
     chars_to_remove = ["$", "(", ")", "[", "]", "{", "}"]
 
-    for i, name in enumerate(factor_names):
+    sanitized_factor_names = factor_names[:]
+    for i, name in enumerate(sanitized_factor_names):
         for symbol in chars_to_replace_with_underscore:
             if symbol in name:
                 warnings.warn(
@@ -119,20 +120,18 @@ def sanitize_names_for_patsy(factor_names):
                         "mathematical symbols. Replacing with underscore"
                     )
                 )
-                factor_names[i] = name.replace(symbol, "_")
-                name = factor_names[i]
+                sanitized_factor_names[i] = name.replace(symbol, "_")
+                name = sanitized_factor_names[i]
         for symbol_rm in chars_to_remove:
             if symbol_rm in name:
-                factor_names[i] = name.replace(symbol_rm, "")
-                name = factor_names[i]
-
-    if len(factor_names) != len(set(factor_names)):
+                sanitized_factor_names[i] = name.replace(symbol_rm, "")
+                name = sanitized_factor_names[i]
+    if len(sanitized_factor_names) != len(set(sanitized_factor_names)):
         raise ValueError(
             "Duplicate factor names found after sanitation."
             " Factor names must be unique."
         )
-
-    return factor_names
+    return sanitized_factor_names
 
 
 def round_design_point_values(design_points, res):

--- a/ProcessOptimizer/tests/test_doe.py
+++ b/ProcessOptimizer/tests/test_doe.py
@@ -195,6 +195,7 @@ def test_sanitize_names_for_patsy():
         result = sanitize_names_for_patsy(factor_names)
 
     assert result == expected
+    assert factor_names != result
 
 
 @pytest.mark.fast_test

--- a/ProcessOptimizer/tests/test_doe.py
+++ b/ProcessOptimizer/tests/test_doe.py
@@ -312,6 +312,45 @@ def test_get_optimal_DOE_without_categorical(sample_space):
     np.testing.assert_array_almost_equal(result_compare, exptected_result)
 
 
+def test_get_optimal_DOE_and_sanitize_names():
+    """Test the get_optimal_DOE function without categorical dimensions.
+    Use some bad names to ensure this works together.
+    """
+
+    sample_space_bad_names = Space([Real(0, 10, name="x$1"),
+                                    Real(-5, 5, name="x+2*]")])
+    with pytest.warns(UserWarning):
+        result, factor_names = get_optimal_DOE(
+            sample_space_bad_names, budget=12, design_type="optimization",
+            res=11, seed=42
+        )
+
+    result_compare = np.asarray(result, dtype=float)
+
+    exptected_result = np.array(
+        [
+            [0.0, -5.0],
+            [3.0, -5.0],
+            [10.0, 5.0],
+            [0.0, 5.0],
+            [2.0, -2.0],
+            [10.0, -5.0],
+            [7.0, 5.0],
+            [10.0, 2.0],
+            [0.0, 2.0],
+            [7.0, -5.0],
+            [3.0, 3.0],
+            [8.0, -2.0],
+        ]
+    )
+
+    assert result.shape == (12, 2)
+    assert np.all(result[:, 0] >= 0) and np.all(result[:, 0] <= 10)
+    assert np.all(result[:, 1] >= -5) and np.all(result[:, 1] <= 5)
+    assert factor_names == ["x1", "x_2_"]
+    np.testing.assert_array_almost_equal(result_compare, exptected_result)
+
+
 def test_get_optimal_DOE_with_categorical(optimal_design_space):
     """Test the get_optimal_DOE function with a categorical dimension."""
     result, factor_names = get_optimal_DOE(


### PR DESCRIPTION
Right now you will easily accidentally change your variables when you run them through the sanitize_names_for_patsy function. I have changed this and extended test to ensure inputs are unchanged. 