### PR TITLE
Multiobjective functionality for Brownie Bee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - Added the get_Brownie_Bee_Pareto() function to support Pareto front plotting in the Brownie Bee user interface.
+- Added the get_Pareto_front_compromise() function to facilitate a default highlighted compromise in the Pareto plot.
+- Added the get_Brownie_Bee_1d_plot() function to support custom 1D dependency plots in the Brownie Bee user interface.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Changes
 
-- 
+- Added the get_Brownie_Bee_Pareto() function to support Pareto front plotting in the Brownie Bee user interface.
 
 ### Bugfixes
 
-- 
+- opt.ask() is now reproducible for multiobjective optimization through seeding of the NSGAII algorithm and
+  a small adjustment to the way optimizer._tell() chooses between Steinerberger and NSGAII sampling.
+- Pareto front calculations are now reproducible.
 
 ## Version 1.1.1 [published]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - opt.ask() is now reproducible for multiobjective optimization through seeding of the NSGAII algorithm and
   a small adjustment to the way optimizer._tell() chooses between Steinerberger and NSGAII sampling.
 - Pareto front calculations are now reproducible.
+- Fixes small error in legend generation of plot_objective_1d for the case where the user specifies a
+  specific set of settings to create the plot at
 
 ## Version 1.1.1 [published]
 

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -1309,7 +1309,12 @@ class Optimizer(object):
     # This function calls NSGAII to estimate the Pareto Front
     def NSGAII(self, MU=40):
         from ._NSGA2 import NSGAII
-
+        
+        if MU % 4 != 0:
+            raise ValueError(
+                "Number of simulated points must be divisible by 4 for the NSGAII algorithm"
+            )
+            
         pop, logbook, front = NSGAII(
             self.n_objectives,
             self.__ObjectiveGP,

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -753,7 +753,7 @@ class Optimizer(object):
                 prob_stbr = 0.25
 
                 # Simulate a random number
-                random_uniform_number = np.random.uniform()
+                random_uniform_number = self.rng.uniform()
 
                 # The random number decides what strategy to use for the next point
                 if random_uniform_number < prob_stbr:

--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -1315,6 +1315,7 @@ class Optimizer(object):
             self.__ObjectiveGP,
             np.array(self.space.transformed_bounds),
             MU=MU,
+            seed=42,
         )
 
         return pop, logbook, front

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -2591,7 +2591,11 @@ def get_Brownie_Bee_Pareto(optimizer):
     * `front_y`: [numpy.ndarray]:
         Pareto front locations in optimizer Y-space
     * `objective1_error`: [numpy.ndarray]:
-        Uncertainty (1.96*std) of objective 1 values at the front_y locations
+        Uncertainty (1.96*std) of objective 1 values at the front_y locations,
+        including observational noise
+    * `objective2_error`: [numpy.ndarray]:
+        Uncertainty (1.96*std) of objective 2 values at the front_y locations,
+        including observational noise
     """
     
     if optimizer.models == []:

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -11,6 +11,7 @@ from scipy.optimize import OptimizeResult
 from scipy.stats.mstats import mquantiles
 from scipy.stats import norm
 from scipy.ndimage import gaussian_filter1d
+from scipy.signal import savgol_filter
 from warnings import warn
 from ProcessOptimizer import expected_minimum, expected_minimum_random_sampling
 from .space import Categorical, Integer
@@ -2571,3 +2572,65 @@ def plot_Pareto_bokeh(
             json_item = bh_embed.json_item(p)
             return json_item
 
+
+def get_Brownie_Bee_Pareto(optimizer):
+    """Calculate Pareto front in two dimensions and return its points, as well
+    as uncertainty band around each objective along the front. This function is
+    mainly intended for use with the Brownie Bee user interface.
+
+    Parameters
+    ----------
+    * `optimizer` [`Optimizer`]
+        The optimizer containing data and the multiobjective model
+
+
+    Returns
+    -------
+    * `front_x`: [numpy.ndarray]:
+        Pareto front locations in optimizer X-space
+    * `front_y`: [numpy.ndarray]:
+        Pareto front locations in optimizer Y-space
+    * `objective1_error`: [numpy.ndarray]:
+        Uncertainty (1.96*std) of objective 1 values at the front_y locations
+    """
+    
+    if optimizer.models == []:
+        raise ValueError("No models have been fitted yet")
+
+    if optimizer.n_objectives == 1:
+        raise ValueError(
+            "get_Pareto_points is not possible with single objective optimization"
+        )
+
+    if optimizer.n_objectives > 2:
+        raise ValueError("get_Pareto_points is not possible with >2 objectives")
+    
+    # Estimate the Pareto front of the models in the optimizer object
+    front_x, logbook, front_y = optimizer.NSGAII(MU=100)
+
+    front_x = np.asarray(front_x)
+    front_x = np.asarray(
+        optimizer.space.inverse_transform(
+            front_x.reshape(len(front_x), optimizer.space.transformed_n_dims)
+        )
+    )
+    
+    # Sort the points in ascending order on objective 1
+    idx = np.argsort(front_y[:, 0])
+    front_x = front_x[idx, :]
+    front_y = front_y[idx, :]
+    
+    # Extract estimates of the objective functions along the Pareto front
+    output = optimizer.estimate(front_x)
+    # Grab objective errors and smooth them slightly along the front
+    objective1_error = [1.96*point.Y1.std for point in output]
+    objective1_error = savgol_filter(objective1_error, 11, 1, mode="interp")
+    objective2_error = [1.96*point.Y2.std for point in output]
+    objective2_error = savgol_filter(objective2_error, 11, 1, mode="interp")
+    
+    return (
+        front_x,
+        front_y,
+        objective1_error,
+        objective2_error,
+    )

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -1454,9 +1454,9 @@ def plot_objective_1d(
                     highlight_label = "Expected minimum"
                 elif pars == "expected_minimum_random":
                     highlight_label = "Simulated minimum"
-                elif isinstance(pars, list):
-                    # The case where the user specifies [x[0], x[1], ...]
-                    highlight_label = "Point: " + str(pars)
+            elif isinstance(pars, list):
+                # The case where the user specifies [x[0], x[1], ...]
+                highlight_label = "Point: " + str(pars)
             # Legend icon for the highlighted value
             legend_hl = mpl.lines.Line2D(
                 [],

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -1556,7 +1556,11 @@ def get_Brownie_Bee_1d_plot(
         A list of lists that provide the necessary data for creating dependency
         plots along each dimension of the space. Each list contains three lists
         and a float of the x-axis value to highlight in the same plot: 
-        [[x-axis], [y_low], [y_high], x_highlight] 
+        [[x-axis], [y_low], [y_high], x_highlight].
+        
+        The last entry in plot_list contains information on the mean and std of
+        the model predictions at x_eval. This data allows the user to build a
+        histogram of expected results at these settings.
     """
     space = result.space
     model = result.models[-1]
@@ -1583,6 +1587,7 @@ def get_Brownie_Bee_1d_plot(
     # Gather all data relevant for plotting
     plot_list = []
     
+    # Generate 1D plot information for each dimension in space
     for i in range(space.n_dims):
         xi, yi, stddevs = dependence(
             space,
@@ -1599,6 +1604,9 @@ def get_Brownie_Bee_1d_plot(
             (yi+1.96*stddevs).tolist(),
             highlight[i],
         ])
+    
+    # Add information about the expected results at x_eval
+    plot_list.append([res_mean, res_std])
 
     return plot_list
 

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -1515,6 +1515,94 @@ def plot_objective_1d(
         ax, space, ylabel=ylabel, dim_labels=dimensions
     )
 
+
+def get_Brownie_Bee_1d_plot(
+        result,
+        x_eval=None,
+        n_points=60,
+        n_samples=250,
+):
+    """Returns the information needed to produce single factor dependence plots
+    of the model in `result`. This utility function is mainly intended for use 
+    with the Brownie Bee user interface.
+    
+    The data returned allows visualization of how Y depends on dimension `i` 
+    when all other factor values are locked to those provided in x_eval.
+    
+    Parameters
+    ----------
+    * `result` [`OptimizeResult`]
+        The result for which to create the plotting data.
+    
+    * `x_eval` [list or np.ndarray of floats, ints and/or strings, default=None] 
+        [x[0], x[1], ..., x[n]] - Factor settings to create the dependency plot 
+        at, defined by the values in this list. Depending on the system, this 
+        list can contain a mixture of floats, ints and strings. If no settings 
+        are provided the function defaults to using expected_minimum on the 
+        model.
+        
+    * `n_points` [int, default=60]
+        Number of points at which to evaluate the partial dependence
+        along each dimension.
+
+    * `n_samples` [int, default=250]
+        Number of random samples to use for averaging the model function
+        at each of the `n_points`.
+
+
+    Returns
+    -------
+    * `plot_list`: [`list of lists`]:
+        A list of lists that provide the necessary data for creating dependency
+        plots along each dimension of the space. Each list contains three lists
+        and a float of the x-axis value to highlight in the same plot: 
+        [[x-axis], [y_low], [y_high], x_highlight] 
+    """
+    space = result.space
+    model = result.models[-1]
+    
+    if x_eval is None:
+        # Identify the location of the expected minimum, and its mean and std
+        x_eval, [res_mean, res_std] = expected_minimum(
+            result,
+            n_random_starts=20,
+            random_state=42,
+            return_std=True,
+        )
+    elif isinstance(x_eval, list) or isinstance(x_eval, np.ndarray):
+        assert len(x_eval) == len(space), "Input settings must have same length as number of features"
+        res_mean, res_std = model.predict(np.array(x_eval).reshape(1, -1), return_std=True)
+    else:
+        raise TypeError("x_eval must be a list of settings, or None")
+    
+    rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
+    # Map the settings to highlight so we automatically take care of 
+    # categorical factors that use 1-hot encoding
+    _, highlight, _ = _map_categories(space, result.x_iters, x_eval)
+    
+    # Gather all data relevant for plotting
+    plot_list = []
+    
+    for i in range(space.n_dims):
+        xi, yi, stddevs = dependence(
+            space,
+            model,
+            i,
+            j=None,
+            sample_points=rvs_transformed,
+            n_points=n_points,
+            x_eval=x_eval,
+        )
+        plot_list.append([
+            xi.tolist(),
+            (yi-1.96*stddevs).tolist(),
+            (yi+1.96*stddevs).tolist(),
+            highlight[i],
+        ])
+
+    return plot_list
+
+
 def plot_brownie_bee_frontend(
     result,
     n_points=60,

--- a/ProcessOptimizer/plots.py
+++ b/ProcessOptimizer/plots.py
@@ -2661,7 +2661,7 @@ def plot_Pareto_bokeh(
             return json_item
 
 
-def get_Brownie_Bee_Pareto(optimizer):
+def get_Brownie_Bee_Pareto(optimizer, n_points=100):
     """Calculate Pareto front in two dimensions and return its points, as well
     as uncertainty band around each objective along the front. This function is
     mainly intended for use with the Brownie Bee user interface.
@@ -2670,7 +2670,9 @@ def get_Brownie_Bee_Pareto(optimizer):
     ----------
     * `optimizer` [`Optimizer`]
         The optimizer containing data and the multiobjective model
-
+    * `n_points` [int, default=100]
+        The number of points to simulate for the Pareto front. Must be a 
+        multiple of 4 for the NSGAII algorithm.
 
     Returns
     -------
@@ -2697,8 +2699,13 @@ def get_Brownie_Bee_Pareto(optimizer):
     if optimizer.n_objectives > 2:
         raise ValueError("get_Pareto_points is not possible with >2 objectives")
     
+    if n_points % 4 != 0:
+        raise ValueError(
+            "Number of simulated points must be divisible by 4 for the NSGAII algorithm"
+        )
+    
     # Estimate the Pareto front of the models in the optimizer object
-    front_x, logbook, front_y = optimizer.NSGAII(MU=100)
+    front_x, logbook, front_y = optimizer.NSGAII(MU=n_points)
 
     front_x = np.asarray(front_x)
     front_x = np.asarray(

--- a/ProcessOptimizer/tests/test_multiobjective.py
+++ b/ProcessOptimizer/tests/test_multiobjective.py
@@ -70,3 +70,24 @@ def test_Pareto_reproducible():
     pop2, logbook, front2 = opt.NSGAII()
     assert_equal(pop1, pop2)
     assert_equal(front1, front2)
+
+
+@pytest.mark.fast_test
+def test_multiobjective_ask_reproducible():
+    gold_model_system = get_model_system('gold_map')
+    distance_model_system = get_model_system('distance_map', camp_coordinates=(4,10))
+
+    opt1 = Optimizer(gold_model_system.space, n_initial_points=4, n_objectives=2)
+    opt2 = Optimizer(gold_model_system.space, n_initial_points=4, n_objectives=2)
+
+    gold_model_system.noise_model.set_seed(40)
+    distance_model_system.noise_model.set_seed(40)
+    # Check that the two optimizers stay in sync
+    for i in range(40):
+        new_dig_site_1 = opt1.ask()
+        new_dig_site_2 = opt2.ask()
+        assert_equal(new_dig_site_1, new_dig_site_2)
+        gold_found = gold_model_system.get_score(new_dig_site_1)
+        distance = distance_model_system.get_score(new_dig_site_1)
+        opt1.tell(new_dig_site_1, [gold_found, distance])
+        opt2.tell(new_dig_site_2, [gold_found, distance])

--- a/ProcessOptimizer/tests/test_multiobjective.py
+++ b/ProcessOptimizer/tests/test_multiobjective.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_equal
 
 
 from ProcessOptimizer import Optimizer
+from ProcessOptimizer.model_systems import get_model_system
 
 
 @pytest.mark.fast_test
@@ -46,3 +47,26 @@ def test_Pareto_in_space():
     # Assert that Pareto points are in space
     for x in pop:
         assert_equal(opt.space.__contains__(x), True)
+
+
+@pytest.mark.fast_test
+def test_Pareto_reproducible():
+    gold_model_system = get_model_system('gold_map')
+    distance_model_system = get_model_system('distance_map', camp_coordinates=(4,10))
+
+    opt = Optimizer(gold_model_system.space, n_initial_points=4, n_objectives=2)
+
+    gold_model_system.noise_model.set_seed(40)
+    distance_model_system.noise_model.set_seed(40)
+
+    for i in range(10):
+        new_dig_site = opt.ask()
+        gold_found = gold_model_system.get_score(new_dig_site)
+        distance = distance_model_system.get_score(new_dig_site)
+        opt.tell(new_dig_site, [gold_found, distance])
+    
+    # Calculate Pareto front twice and compare
+    pop1, logbook, front1 = opt.NSGAII()
+    pop2, logbook, front2 = opt.NSGAII()
+    assert_equal(pop1, pop2)
+    assert_equal(front1, front2)

--- a/ProcessOptimizer/utils/utils.py
+++ b/ProcessOptimizer/utils/utils.py
@@ -583,3 +583,43 @@ def y_coverage(res, return_plot=False, random_state=None, horizontal=False):
             plt.show()
 
     return (observed_min, observed_max), (expected_min, expected_max)
+
+
+def get_Pareto_front_compromise(front_y):
+    """Support function to identify a default compromise between two objectives
+    in a Pareto front. This function is mainly intended for use with the 
+    Brownie Bee user interface.
+
+    Parameters
+    ----------
+    * `front_y` [numpy.ndarray]
+        Pareto front locations in optimizer Y-space
+
+
+    Returns
+    -------
+    * `best_idx`: [int]:
+        The index of the point in front_y that is closest to the normalized
+        ideal solution for both objectives.
+    """
+    if not isinstance(front_y, np.ndarray):
+        raise TypeError("front_y must be a numpy.ndarray, got (%s)." % type(front_y))
+    
+    if front_y.shape[1] != 2:
+        raise ValueError("front_y must have two columns, got (%s)" % front_y.shape[1])
+    
+    # Get the best predicted point for each objective
+    best_obj1 = np.min(front_y[:, 0])
+    best_obj2 = np.min(front_y[:, 1])
+    # Get the span of each objective for normalization
+    span1 = np.ptp(front_y[:, 0])
+    span2 = np.ptp(front_y[:, 1])
+
+    # Calculate distance from ideal solution to points along the front
+    dist = np.sqrt(
+          ((front_y[:, 0] - best_obj1)/span1)**2 
+        + ((front_y[:, 1] - best_obj2)/span2)**2 
+    )
+    best_idx = np.argmin(dist)
+    
+    return best_idx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ browniebee = [
     "scipy==1.13.0",
     "six==1.16.0",
     "patsy==1.0.1",
+	"torch==2.8.0",
 ]
 release = [
     "build==1.2.2.post1"


### PR DESCRIPTION
This pull request adds supporting functionality for multiobjective optimization in Brownie Bee. Specifically, Brownie Bee needs to be able to handle plotting of the Pareto front on its own and I have therefore built functions that deliver information about the Pareto front location, its uncertainty in both objective values and a function to select a default point on the front to highlight.

A side-effect of me doing this work is that I discovered several places where functionality related to multiobjective optimization was not reproducible. This was true both for multiobjective opt.ask() and for Pareto front calculations. I have therefore made changes to RNG and seeding in a couple of places to fix this as well.

Below follows a simple script demonstrating the intended use-case that the code supports:
```python
import matplotlib.pyplot as plt
import numpy as np

from ProcessOptimizer import Optimizer
from ProcessOptimizer.plots import get_Brownie_Bee_Pareto
from ProcessOptimizer.model_systems import get_model_system
from ProcessOptimizer.utils.utils import get_Pareto_front_compromise

#%% Set up two simple functions to draw data from
gold_model_system = get_model_system('gold_map')
distance_model_system = get_model_system('distance_map', camp_coordinates=(4,10))

opt = Optimizer(gold_model_system.space, n_initial_points=4, n_objectives=2)

gold_model_system.noise_model.set_seed(40)
distance_model_system.noise_model.set_seed(40)

for i in range(16):
    new_dig_site = opt.ask()
    gold_found = gold_model_system.get_score(new_dig_site)
    distance = distance_model_system.get_score(new_dig_site)
    result_list = opt.tell(new_dig_site, [gold_found, distance])

front_x_data, front_y_data, obj1_error, obj2_error = get_Brownie_Bee_Pareto(opt)

plt.figure(figsize=(10, 10))

# Plot observations
plt.scatter(np.array(opt.yi)[:, 0], np.array(opt.yi)[:, 1], color="k")
# Plot the central points in the Pareto front
plt.plot(front_y_data[:, 0], front_y_data[:, 1], color="k")

# Show bands of uncertainty on each objective
plt.fill_between(
    front_y_data[:, 0], 
    front_y_data[:, 1] - obj2_error, 
    front_y_data[:, 1] + obj2_error, 
    alpha=0.2, 
    color="orange",
)
plt.fill_betweenx(
    front_y_data[:, 1],
    front_y_data[:, 0] - obj1_error,
    front_y_data[:, 0] + obj1_error,
    alpha=0.2,
    color="green",
)
plt.xlabel("Objective 1")
plt.ylabel("Objective 2")

# Get best compromise at present and show it
best_idx = get_Pareto_front_compromise(front_y_data)
plt.scatter(front_y_data[best_idx, 0], front_y_data[best_idx, 1], color="r")
```

The resulting figure looks like this:
<img width="1000" height="1000" alt="Figure_1" src="https://github.com/user-attachments/assets/b6a50de4-f401-49cb-9bdf-54bf4d1ed75c" />
