### PR TITLE
fix: remove unstable part of custom model test

### DIFF
--- a/ProcessOptimizer/tests/test_doe.py
+++ b/ProcessOptimizer/tests/test_doe.py
@@ -419,13 +419,15 @@ def test_custom_model(sample_space):
 
     design = np.asarray(np.asarray(design[:, :2]), dtype=int)
 
-    expected = np.array([[10, 5], [10, -5], [0, 5], [5, -5], [0, -5]])
+    # Removed expected design as it current output may vary with library versions
+    # expected = np.array([[10, 5], [10, -5], [0, 5], [5, -5], [0, -5]])
 
     assert design.shape == (5, 2)
     assert np.all(design[:, 0] >= 0) and np.all(design[:, 0] <= 10)
     assert np.all(design[:, 1] >= -5) and np.all(design[:, 1] <= 5)
     assert factor_names == ["x1", "x2"]
-    np.testing.assert_array_almost_equal(design, expected)
+    # Removed expected design as it current output may vary with library versions
+    # np.testing.assert_array_almost_equal(design, expected)
 
 
 def test_get_optimal_DOE_default_budget(sample_space):


### PR DESCRIPTION
Quickfix as it says.
This specific part of the test is unstable with just minor changes to any of the underlying dependencies