### PR TITLE
Acquisition function key-word arguments aren't all passed to Optimizer at initialization

### DIFF
--- a/ProcessOptimizer/optimizer/optimizer.py
+++ b/ProcessOptimizer/optimizer/optimizer.py
@@ -266,6 +266,7 @@ class Optimizer(object):
                 length_scale_bounds=self._length_scale_bounds,
                 length_scale=self._length_scale,
                 noise_level_bounds=noise_level_bounds,
+                n_restarts_optimizer=self.n_restarts_optimizer,
             )
 
         # check if regressor


### PR DESCRIPTION
Closes #353 

`base_estimator.set_params(**kwargs)` at the end, optimizer.py never passes n_restarts_optimizer through to it. The fix is to add it to the cook_estimator call.

`n_restarts_optimizer` was being read from `acq_optimizer_kwargsv and stored on self, but never forwarded to cook_estimator, which `hardcodes n_restarts_optimizer=4` internally. Since `cook_estimator` applies `**kwargs` via `base_estimator.set_params(...)` at the `end,` passing it through as a kwarg now overrides that hardcoded value correctly.